### PR TITLE
Fix task 2 test bypass

### DIFF
--- a/tests/Feature/RelationshipsTest.php
+++ b/tests/Feature/RelationshipsTest.php
@@ -34,6 +34,7 @@ class RelationshipsTest extends TestCase
         Task::create(['name' => 'Some task']);
 
         $response = $this->get('/tasks');
+        $response->assertSeeText('Some task');
         $response->assertStatus(200);
     }
 


### PR DESCRIPTION
This PR adds a fix for the test bypass discussed in #1 by checking for the existence of the task. With this test, users should now not be able to make the test pass without the task being there.