### PR TITLE
Fix Task 6 - average of the field

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -9,7 +9,7 @@ class Team extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'size'];
+    protected $fillable = ['name', 'size', 'country_id'];
 
     public function users()
     {

--- a/tests/Feature/RelationshipsTest.php
+++ b/tests/Feature/RelationshipsTest.php
@@ -105,6 +105,7 @@ class RelationshipsTest extends TestCase
 
         $response = $this->get('/countries');
         $response->assertSee('avg team size 4');
+        $response->assertStatus(200);
     }
 
     // TASK: polymorphic relations


### PR DESCRIPTION
This PR fixes the broken task of getting the average of a team attached to a country. I know this is pretty late and most users probably have the correct idea, but as pointed out in #28. 

The test case passes with arbitrary queries due to the fact that the test case doesn't check for a 200 OK status code. That coupled with the fact that `country_id` wasn't fillable in teams means this test case was never going to pass even with the correct query.

With this PR the test case should now behave as originally intended for new forks. Already submitted PRs will have to merge in main and re-submit if they want to test their solutions against the fix.